### PR TITLE
docs: 修改项目许可证为Apache License 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,4 +99,4 @@ npm test
 
 ## License
 
-MIT
+Apache License 2.0


### PR DESCRIPTION
将原MIT许可证替换为Apache License 2.0，更新README中的许可证声明